### PR TITLE
Create Brittany.txt

### DIFF
--- a/0_RawCivCityLists/Brittany.txt
+++ b/0_RawCivCityLists/Brittany.txt
@@ -1,0 +1,16 @@
+Brest
+Rennes
+Nantes
+Quimper
+Lorient
+Saint-Malo
+Vannes
+Saint-Brieuc
+Dinan
+Plougastel
+Guingamp
+Morlaix
+Saint-Pol-de-Leon
+Carnoet
+Audierne
+Brehan


### PR DESCRIPTION
13 Cities for Brittany. The names are the current French names, although accents have been avoided.
